### PR TITLE
Fix missing name in `Register.svelte`

### DIFF
--- a/resources/js/pages/auth/Register.svelte
+++ b/resources/js/pages/auth/Register.svelte
@@ -19,7 +19,7 @@
             <div class="grid gap-6">
                 <div class="grid gap-2">
                     <Label for="name">Name</Label>
-                    <Input id="name" type="text" required autofocus tabindex={1} autocomplete="name" placeholder="Full name" />
+                    <Input id="name" name="name" type="text" required autofocus tabindex={1} autocomplete="name" placeholder="Full name" />
                     <InputError message={errors.name} />
                 </div>
 


### PR DESCRIPTION
@oseughu The `name` attribute is missing in the `name` input in the registration form, causing the validation to fail as it is a required field.

****To reproduce****
1. Make a clean install `laravel new blueprinthub --using=oseughu/svelte-starter-kit`
2. Run `composer run dev`
3. Go to `http://127.0.0.1:8000/register`
4. Fill the registration form and submit it.
5. You won't be able to submit it with the `The name field is required.` error, even if the field is filled.
<img width="482" height="658" alt="Screenshot 2025-08-22 at 08 55 54" src="https://github.com/user-attachments/assets/8e04b5a4-b753-4358-aa65-06fd96c4c375" />
