### PR TITLE
Fix deprecated Laravel installer syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Welcome to the **Laravel + Svelte Starter Kit**! This project is your launchpad 
 Ready to blast off? Spin up a new project in seconds:
 
 ```bash
-laravel new larasvelte --using=oseughu/svelte-starter-kit
+composer create-project oseughu/svelte-starter-kit larasvelte
 ```
 
 Want to try the **WorkOS integration branch**? Use:
 
 ```bash
-laravel new larasvelte --using=oseughu/svelte-starter-kit:dev-workos
+composer create-project oseughu/svelte-starter-kit:dev-workos larasvelte
 ```
 
 Just replace `larasvelte` with your dream project name!


### PR DESCRIPTION
The README.md contained installation instructions using the deprecated `--using` option for Laravel installer, which is no longer supported in recent versions and causes the error: `The "--using" option does not exist.`

I've updated the README to fix the deprecated Laravel installer syntax. The solution replaces the old `laravel new --using=` commands with the modern `composer create-project` approach:

**Old (deprecated) syntax:**
```bash
laravel new larasvelte --using=oseughu/svelte-starter-kit
```

**New (recommended) syntax:**
```bash
composer create-project oseughu/svelte-starter-kit larasvelte
```

This change ensures users can successfully install the starter kit since the `--using` option no longer exists in recent Laravel installer versions. The `composer create-project` method is the standard way to create new projects from packages and works with all current versions of Composer and Laravel tooling.